### PR TITLE
タスクの編集ボタンとデリートボタンの追加

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,0 +1,123 @@
+import flet
+from flet import (
+    Checkbox,
+    Column,
+    FloatingActionButton,
+    IconButton,
+    Page,
+    Row,
+    TextField,
+    UserControl,
+    colors,
+    icons,
+)
+
+
+class Task(UserControl):
+    def __init__(self, task_name, task_delete):
+        super().__init__()
+        self.task_name = task_name
+        self.task_delete = task_delete
+
+    def build(self):
+        self.display_task = Checkbox(value=False, label=self.task_name)
+        self.edit_name = TextField(expand=1)
+
+        self.display_view = Row(
+            alignment="spaceBetween",
+            vertical_alignment="center",
+            controls=[
+                self.display_task,
+                Row(
+                    spacing=0,
+                    controls=[
+                        IconButton(
+                            icon=icons.CREATE_OUTLINED,
+                            tooltip="Edit To-Do",
+                            on_click=self.edit_clicked,
+                        ),
+                        IconButton(
+                            icons.DELETE_OUTLINE,
+                            tooltip="Delete To-Do",
+                            on_click=self.delete_clicked,
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        self.edit_view = Row(
+            visible=False,
+            alignment="spaceBetween",
+            vertical_alignment="center",
+            controls=[
+                self.edit_name,
+                IconButton(
+                    icon=icons.DONE_OUTLINE_OUTLINED,
+                    icon_color=colors.GREEN,
+                    tooltip="Update To-Do",
+                    on_click=self.save_clicked,
+                ),
+            ],
+        )
+        return Column(controls=[self.display_view, self.edit_view])
+
+    def edit_clicked(self, e):
+        self.edit_name.value = self.display_task.label
+        self.display_view.visible = False
+        self.edit_view.visible = True
+        self.update()
+
+    def save_clicked(self, e):
+        self.display_task.label = self.edit_name.value
+        self.display_view.visible = True
+        self.edit_view.visible = False
+        self.update()
+
+    def delete_clicked(self, e):
+        self.task_delete(self)
+
+
+class TodoApp(UserControl):
+    def build(self):
+        self.new_task = TextField(hint_text="Whats needs to be done?", expand=True)
+        self.tasks = Column()
+
+        # application's root control (i.e. "view") containing all other controls
+        return Column(
+            width=600,
+            controls=[
+                Row(
+                    controls=[
+                        self.new_task,
+                        FloatingActionButton(icon=icons.ADD, on_click=self.add_clicked),
+                    ],
+                ),
+                self.tasks,
+            ],
+        )
+
+    def add_clicked(self, e):
+        task = Task(self.new_task.value, self.task_delete)
+        self.tasks.controls.append(task)
+        self.new_task.value = ""
+        self.update()
+
+    def task_delete(self, task):
+        self.tasks.controls.remove(task)
+        self.update()
+
+
+def main(page: Page):
+    page.title = "ToDo App"
+    page.horizontal_alignment = "center"
+    page.update()
+
+    # create application instance
+    app = TodoApp()
+
+    # add application's root control to the page
+    page.add(app)
+
+
+flet.app(target=main)

--- a/main.py
+++ b/main.py
@@ -1,10 +1,77 @@
 import flet as ft
 
+#TODO DleteメソッドをTaskクラスに渡す理由
+
+# UserControlとは？
+class Task(ft.UserControl):
+    def __init__(self, task_name, delte_task):
+        super().__init__()
+        self.task_name = task_name
+        self.delte_task = delte_task
+    def build(self):
+        self.display_task = ft.Checkbox(label = self.task_name)
+        self.edit_task_name = ft.TextField()
+        
+        # 通常表示
+        self.default_task_view = ft.Row(
+            controls= [
+                self.display_task,
+                ft.Row(
+                    controls = [
+                        ft.IconButton(
+                            icon=ft.icons.CREATE_OUTLINED,
+                            tooltip="タスクを編集",
+                            on_click=self.edit_clicked,
+                        ),
+                        ft.IconButton(
+                            icon = ft.icons.DELETE_OUTLINE,
+                            tooltip = "タスクを削除",
+                            on_click = self.delete_clicked,
+                        ),
+                    ]
+                ),
+            ]
+        )
+        
+        
+        # 編集ボタンが押された時（普段は隠しておく）
+        self.edit_task_view = ft.Row(
+            visible=False,
+            controls=[
+                self.edit_task_name,
+                ft.IconButton(
+                    icon=ft.icons.DONE_OUTLINE_OUTLINED,
+                    icon_color=ft.colors.GREEN,
+                    tooltip="タスク更新",
+                    on_click=self.save_clicked,
+                ),
+            ],
+        )
+        return ft.Column(controls=[self.default_task_view, self.edit_task_view])
+    
+    # TODO 引数eは何を意味しているのか？
+    def edit_clicked(self, e):
+        self.default_task_view.visible = False
+        self.edit_task_view.visible = True
+        self.edit_task_name.value = self.task_name
+        
+        self.update()
+    
+    def delete_clicked(self, e):
+        self.delte_task(self)
+        
+    def save_clicked(self, e):
+        self.display_task.label = self.edit_task_name.value
+        self.default_task_view.visible = True
+        self.edit_task_view.visible = False
+        
+        self.update()
+
 class TodoApp(ft.UserControl):
     def build(self):
         self.new_task = ft.TextField(hint_text = 'やるべきこと', expand = True)
-        self.add_task_button = ft.ElevatedButton(text = '追加', icon = 'add',on_click = self.button_clicked)
-        self.task_view = ft.Column()
+        self.add_task_button = ft.ElevatedButton(text = '追加', icon = 'add',on_click = self.add_clicked)
+        self.tasks = ft.Column()
         
         return ft.Column(
             controls = [
@@ -14,13 +81,17 @@ class TodoApp(ft.UserControl):
                         self.add_task_button
                     ]
                 ),
-                self.task_view
+                self.tasks
             ]
         )
         
+    def delete_task(self, task):
+        self.tasks.controls.remove(task)
+        self.update()
     
-    def button_clicked(self, e):
-        self.task_view.controls.append(ft.Checkbox(label = self.new_task.value))
+    def add_clicked(self, e):
+        self.task = Task(task_name=self.new_task.value, delte_task=self.delete_task)
+        self.tasks.controls.append(self.task)
         self.new_task.value = ''
         # 特定のWidgetにのみ変更を加えられることができる
         self.update()


### PR DESCRIPTION
## 概要
- タスクを編集するボタンの追加
- タスクを削除するボタンの追加

## 内容
それぞれのタスクを保持しておくTasksコントローラーに対して、removeメソッドに呼ぶことで特定のタスクを削除することができる。ただ、Tasksコントローラーを持つのはTodoAppクラスなので、今回のようにTaskクラスで呼ぶようにするためには、タスクを削除する処理（関数）をTodoAppクラスで定義し、Taskクラスに引き渡す必要があるため勉強になった。